### PR TITLE
replaced lists with pluck as its deprecated and removed in laravel 5.3

### DIFF
--- a/src/Http/Controllers/ManyToManyController.php
+++ b/src/Http/Controllers/ManyToManyController.php
@@ -67,7 +67,7 @@ abstract class ManyToManyController extends Controller
     {
         $model_class = $this->config->get('entrust.'.str_singular($this->resource));
         $model = new $model_class;
-        $relations = $this->relation->lists('name', 'id');
+        $relations = $this->relation->pluck('name', 'id');
 
         return view('entrust-gui::'.$this->resource.'.create', compact(
             'model',
@@ -110,7 +110,7 @@ abstract class ManyToManyController extends Controller
     public function edit($id)
     {
         $model = $this->gateway->find($id);
-        $relations = $this->relation->lists('name', 'id');
+        $relations = $this->relation->pluck('name', 'id');
 
         return view('entrust-gui::'.$this->resource.'.edit', compact(
             'model',

--- a/src/Http/Controllers/UsersController.php
+++ b/src/Http/Controllers/UsersController.php
@@ -67,7 +67,7 @@ class UsersController extends Controller
     {
         $user_class = $this->config->get('auth.providers.users.model');
         $user = new $user_class;
-        $roles = $this->role->lists('name', 'id');
+        $roles = $this->role->pluck('name', 'id');
 
         return view(
             'entrust-gui::users.create',
@@ -109,7 +109,7 @@ class UsersController extends Controller
     public function edit($id)
     {
         $user = $this->gateway->find($id);
-        $roles = $this->role->lists('name', 'id');
+        $roles = $this->role->pluck('name', 'id');
 
         return view(
             'entrust-gui::users.edit',


### PR DESCRIPTION
I've replaced the lists() calls with pluck(). The lists function on Collections is deprecated and has been removed in Laravel 5.3.
