### PR TITLE
added config and loading of searchable fields

### DIFF
--- a/config/entrust-gui.php
+++ b/config/entrust-gui.php
@@ -13,5 +13,6 @@ return [
     "confirmable" => false,
     "users" => [
         'deletable' => true,
+        'fieldSearchable' => [],
     ],
 ];

--- a/src/Repositories/UserRepositoryEloquent.php
+++ b/src/Repositories/UserRepositoryEloquent.php
@@ -1,5 +1,6 @@
 <?php namespace Acoustep\EntrustGui\Repositories;
 
+use Illuminate\Container\Container as Application;
 use Prettus\Repository\Eloquent\BaseRepository;
 use Prettus\Repository\Criteria\RequestCriteria;
 use App\Entities\User;
@@ -16,6 +17,12 @@ use Exception;
  */
 class UserRepositoryEloquent extends BaseRepository implements UserRepository
 {
+
+    public function __construct(Application $app) {
+      parent::__construct($app);
+      $this->fieldSearchable = config('entrust-gui.users.fieldSearchable', []);
+    }
+
     /**
      * Specify Model class name
      *
@@ -71,7 +78,7 @@ class UserRepositoryEloquent extends BaseRepository implements UserRepository
         $model = $this->find($id);
         if (! in_array('Esensi\Model\Contracts\HashingModelInterface', class_implements($model))) {
             throw new Exception(
-                "User model must implement Esensi\Model\Contracts\HashingModelInterface. 
+                "User model must implement Esensi\Model\Contracts\HashingModelInterface.
                 Revert to 0.3.* or see upgrade guide for details."
             );
         }


### PR DESCRIPTION
Addresses #17. Totally configurable searchable fields. Same logic could be applied to all models and then abstract the constructor perhaps?

Anyway, this allows for usage of the built-in functionality of l5-repository for searching queried models via request criteria. Usable with URLs like `http://local.dev/trust/users?search=foo&searchFields=name:like`