### PR TITLE
Add searchable fields to user repository and config

### DIFF
--- a/config/entrust-gui.php
+++ b/config/entrust-gui.php
@@ -11,4 +11,7 @@ return [
     "unauthorized-url" => '/login',
     "middleware-role" => 'admin',
     "confirmable" => false,
+    "users" => [
+      'fieldSearchable' => [],
+    ],
 ];

--- a/src/Repositories/UserRepositoryEloquent.php
+++ b/src/Repositories/UserRepositoryEloquent.php
@@ -1,5 +1,6 @@
 <?php namespace Acoustep\EntrustGui\Repositories;
 
+use Illuminate\Container\Container as Application;
 use Prettus\Repository\Eloquent\BaseRepository;
 use Prettus\Repository\Criteria\RequestCriteria;
 use App\Entities\User;
@@ -16,6 +17,13 @@ use Exception;
  */
 class UserRepositoryEloquent extends BaseRepository implements UserRepository
 {
+
+    public function __construct(Application $app) {
+      parent::__construct($app);
+      $this->fieldSearchable = config('entrust-gui.users.fieldSearchable', []);
+    }
+
+
     /**
      * Specify Model class name
      *


### PR DESCRIPTION
Sorry about previous PR - was off the wrong branch.

Addresses #17. Totally configurable searchable fields. Same logic could be applied to all models and then abstract the constructor perhaps?

Anyway, this allows for usage of the built-in functionality of l5-repository for searching queried models via request criteria. Usable with URLs like http://local.dev/trust/users?search=foo&searchFields=name:like